### PR TITLE
"Reset Values"したときTemplate Codeが変化しているケースに対応 / スクリプトを単発リロードする機能も追加

### DIFF
--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionEditor.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionEditor.cs
@@ -36,21 +36,19 @@ namespace Baxter.ClusterScriptExtensions.Editor.Inspector
                 Apply(serializedObject);
             }
 
-            if (GUILayout.Button("Reset Values"))
+            if (GUILayout.Button("Reload Script"))
             {
-                ResetValues(serializedObject);
+                ReloadFields(serializedObject, false);
                 Apply(serializedObject);
             }
-        }
 
-        private static void ResetValues(SerializedObject obj)
-        {
-            var ext = (ScriptableItemExtension)obj.targetObject;
-            foreach (var field in ext.ExtensionFields)
+            if (GUILayout.Button("Reset Values"))
             {
-                field.ResetValues();
+                // 値を巻き戻すのではなく、Field自体をリロードしてしまう。
+                // こっちのほうがスクリプトが変わったケースに対して強いため
+                ReloadFields(serializedObject, true);
+                Apply(serializedObject);
             }
-            EditorUtility.SetDirty(ext);
         }
 
         private static void ReloadFields(SerializedObject obj, bool refreshField)


### PR DESCRIPTION
fixed #7 

仕様

- Reload Script: スクリプトの内容をリロードしつつ、カスタムしていた値はなるべく持ち越す
- Reset Values: 値をリセットする

実際の挙動

- Reload Script: 仕様と一緒: スクリプトの内容をリロードしつつ、カスタムしていた値はなるべく持ち越す
- Reset Values: カスタムしていた値を無視しつつ、スクリプトをリロードする (Reload Scriptにかなり近い挙動にする)

Inspectorの見えはこうなる: 

![image](https://github.com/user-attachments/assets/ac935f22-bff3-4ca8-abde-8c539f8a3323)
