### PR TITLE
アセットやオブジェクトの参照を取れるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ crashlytics-build.properties
 
 # Ignore JetBrains Rider files
 /.idea/
+
+# Ignore internal data to ignore. The folder may include test-only-purposed assets like sound, motion, etc.
+/[Aa]ssets/Internal_Ignored.meta
+/[Aa]ssets/Internal_Ignored/
+

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0114d06fd1cbe7f47babf74bfa8929b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
@@ -10,7 +10,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var elements = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.HumanoidAnimation)
+                .Where(f => f.Type is ExtensionFieldType.HumanoidAnimation && f.HumanoidAnimationClipValue != null)
                 .Select(f => (Id: f.FieldName, Clip: f.HumanoidAnimationClipValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
@@ -7,23 +7,11 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
 {
     public static class HumanoidAnimationListUpdater
     {
-        private readonly struct HumanoidAnimationElement
-        {
-            public string Id { get; }
-            public AnimationClip Clip { get; }
-
-            public HumanoidAnimationElement(string id, AnimationClip clip)
-            {
-                Id = id;
-                Clip = clip;
-            }
-        }        
-
         public static void Update(ScriptableItemExtension ext)
         {
             var elements = ext.ExtensionFields
                 .Where(f => f.Type is ExtensionFieldType.HumanoidAnimation)
-                .Select(f => new HumanoidAnimationElement(f.FieldName, f.HumanoidAnimationClipValue))
+                .Select(f => (Id: f.FieldName, Clip: f.HumanoidAnimationClipValue))
                 .ToArray();
 
             var component = ext.GetComponent<HumanoidAnimationList>();
@@ -45,7 +33,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
                 component = ext.gameObject.AddComponent<HumanoidAnimationList>();
             }
 
-            //NOTE: animationプロパティを触りに行かないといけないので、一旦配列を作ったあとでSerializedObjectとして触りに行く(≒private fieldアクセスをやる)
+            //NOTE: animationプロパティを触りに行かないといけないので、一旦配列を作ったあとでSerializedObjectとして改修する
             var contents = elements
                 .Select(elem => new HumanoidAnimationListEntry(elem.Id, null))
                 .ToArray();

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using ClusterVR.CreatorKit.Item.Implements;
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
+{
+    public static class HumanoidAnimationListUpdater
+    {
+        private readonly struct HumanoidAnimationElement
+        {
+            public string Id { get; }
+            public AnimationClip Clip { get; }
+
+            public HumanoidAnimationElement(string id, AnimationClip clip)
+            {
+                Id = id;
+                Clip = clip;
+            }
+        }        
+
+        public static void Update(ScriptableItemExtension ext)
+        {
+            var elements = ext.ExtensionFields
+                .Where(f => f.Type is ExtensionFieldType.HumanoidAnimation)
+                .Select(f => new HumanoidAnimationElement(f.FieldName, f.HumanoidAnimationClipValue))
+                .ToArray();
+
+            var component = ext.GetComponent<HumanoidAnimationList>();
+
+            // コンポーネントが要らない場合、削除した状態を正とする
+            if (elements.Length == 0)
+            {
+                if (component != null)
+                {
+                    Object.DestroyImmediate(component);
+                    EditorUtility.SetDirty(ext.gameObject);
+                }
+                return;
+            }
+
+            // 必要なら普通に追加
+            if (component == null)
+            {
+                component = ext.gameObject.AddComponent<HumanoidAnimationList>();
+            }
+
+            //NOTE: animationプロパティを触りに行かないといけないので、一旦配列を作ったあとでSerializedObjectとして触りに行く(≒private fieldアクセスをやる)
+            var contents = elements
+                .Select(elem => new HumanoidAnimationListEntry(elem.Id, null))
+                .ToArray();
+            component.Construct(contents);
+
+            var so = new SerializedObject(component);
+            var entriesProperty = so.FindProperty("humanoidAnimations");
+            for (var i = 0; i < contents.Length; i++)
+            {
+                var entryProperty = entriesProperty.GetArrayElementAtIndex(i);
+                entryProperty.FindPropertyRelative("animation").objectReferenceValue = elements[i].Clip;
+            }
+            so.ApplyModifiedProperties();
+        }
+    }    
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/HumanoidAnimationListUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dddf2062dce3ae8419767b12b91e739d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
@@ -15,7 +15,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var audioClipElements = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Where(f => f.Type is ExtensionFieldType.AudioClip && f.AudioClipValue != null)
                 .Select(f => (Id: f.FieldName, Clip: f.AudioClipValue, Loop: f.BoolValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using ClusterVR.CreatorKit.Item;
+using ClusterVR.CreatorKit.Item.Implements;
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
+{
+    /// <summary>
+    /// <see cref="ScriptableItemExtension"/> の内容から、アイテムにアタッチすべきItemAudioSetListを更新するクラス。
+    /// 注意として、このクラスはリストの内容を完全に書き換え、手作業で指定したAudioClip情報は保全しない。
+    /// </summary>
+    public static class ItemAudioSetListUpdater
+    {
+        private readonly struct AudioElement
+        {
+            public string Id { get; }
+            public AudioClip Clip { get; }
+            public bool Loop { get; }
+
+            public AudioElement(string id, AudioClip clip, bool loop)
+            {
+                Id = id;
+                Clip = clip;
+                Loop = loop;
+            }
+        }        
+
+        public static void Update(ScriptableItemExtension ext)
+        {
+            var audioClipElements = ext.ExtensionFields
+                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Select(f => new AudioElement(f.FieldName, f.AudioClipValue, f.BoolValue))
+                .ToArray();
+
+            var component = ext.GetComponent<ItemAudioSetList>();
+
+            // コンポーネントが要らない場合、削除した状態を正とする
+            if (audioClipElements.Length == 0)
+            {
+                if (component != null)
+                {
+                    Object.DestroyImmediate(component);
+                    EditorUtility.SetDirty(ext.gameObject);
+                }
+                return;
+            }
+
+            // 必要なら普通に追加
+            if (component == null)
+            {
+                component = ext.gameObject.AddComponent<ItemAudioSetList>();
+            }
+
+            var itemAudioSets = audioClipElements
+                .Select(elem => new ItemAudioSet(elem.Id, elem.Clip, elem.Loop))
+                .ToArray();
+            component.Construct(itemAudioSets);
+        }
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs
@@ -12,25 +12,11 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
     /// </summary>
     public static class ItemAudioSetListUpdater
     {
-        private readonly struct AudioElement
-        {
-            public string Id { get; }
-            public AudioClip Clip { get; }
-            public bool Loop { get; }
-
-            public AudioElement(string id, AudioClip clip, bool loop)
-            {
-                Id = id;
-                Clip = clip;
-                Loop = loop;
-            }
-        }        
-
         public static void Update(ScriptableItemExtension ext)
         {
             var audioClipElements = ext.ExtensionFields
                 .Where(f => f.Type is ExtensionFieldType.AudioClip)
-                .Select(f => new AudioElement(f.FieldName, f.AudioClipValue, f.BoolValue))
+                .Select(f => (Id: f.FieldName, Clip: f.AudioClipValue, Loop: f.BoolValue))
                 .ToArray();
 
             var component = ext.GetComponent<ItemAudioSetList>();

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemAudioSetListUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 161148e1cebcb8e45968f73656420de2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs
@@ -11,7 +11,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var elements = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.Material)
+                .Where(f => f.Type is ExtensionFieldType.Material && f.MaterialValue != null)
                 .Select(f => (Id: f.FieldName, Material: f.MaterialValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using ClusterVR.CreatorKit.Item;
+using ClusterVR.CreatorKit.Item.Implements;
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
+{
+    public static class ItemMaterialSetListUpdater
+    {
+        public static void Update(ScriptableItemExtension ext)
+        {
+            var elements = ext.ExtensionFields
+                .Where(f => f.Type is ExtensionFieldType.Material)
+                .Select(f => (Id: f.FieldName, Material: f.MaterialValue))
+                .ToArray();
+
+            var component = ext.GetComponent<ItemMaterialSetList>();
+
+            // コンポーネントが要らない場合、削除した状態を正とする
+            if (elements.Length == 0)
+            {
+                if (component != null)
+                {
+                    Object.DestroyImmediate(component);
+                    EditorUtility.SetDirty(ext.gameObject);
+                }
+                return;
+            }
+
+            // 必要なら普通に追加
+            if (component == null)
+            {
+                component = ext.gameObject.AddComponent<ItemMaterialSetList>();
+            }
+
+            var contents = elements
+                .Select(elem => new ItemMaterialSet(elem.Id, elem.Material))
+                .ToArray();
+            component.Construct(contents);
+        }
+    }    
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/ItemMaterialSetListUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16fb909e73f82154cbd4ad2421b9f181
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
@@ -10,7 +10,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var entries = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Where(f => f.Type is ExtensionFieldType.WorldItem)
                 .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
@@ -10,7 +10,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var entries = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.WorldItem)
+                .Where(f => f.Type is ExtensionFieldType.WorldItem && f.ItemReferenceValue != null)
                 .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using ClusterVR.CreatorKit.Item.Implements;
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
+{
+    public static class WorldItemReferenceListUpdater
+    {
+        public static void Update(ScriptableItemExtension ext)
+        {
+            var entries = ext.ExtensionFields
+                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
+                .ToArray();
+
+            var component = ext.GetComponent<WorldItemReferenceList>();
+
+            // コンポーネントが要らない場合、削除した状態を正とする
+            if (entries.Length == 0)
+            {
+                if (component != null)
+                {
+                    Object.DestroyImmediate(component);
+                    EditorUtility.SetDirty(ext.gameObject);
+                }
+                return;
+            }
+
+            // 必要なら普通に追加
+            if (component == null)
+            {
+                component = ext.gameObject.AddComponent<WorldItemReferenceList>();
+            }
+
+            // public propertyがないので、シリアライズした内容ベースでリストを構築する
+            var so = new SerializedObject(component);
+            var entriesProperty = so.FindProperty("worldItemReferences");
+            entriesProperty.ClearArray();
+            for (var i = 0; i < entries.Length; i++)
+            {
+                entriesProperty.InsertArrayElementAtIndex(i);
+                var elem = entriesProperty.GetArrayElementAtIndex(i);
+                elem.FindPropertyRelative("id").stringValue = entries[i].Id;
+                elem.FindPropertyRelative("item").objectReferenceValue = entries[i].Item;
+            }
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemReferenceListUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66aca863e3f6e71488d29dc40dd078a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
@@ -10,7 +10,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var entries = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Where(f => f.Type is ExtensionFieldType.WorldItemTemplate)
                 .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using ClusterVR.CreatorKit.Item.Implements;
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
+{
+    public static class WorldItemTemplateListUpdater
+    {
+        public static void Update(ScriptableItemExtension ext)
+        {
+            var entries = ext.ExtensionFields
+                .Where(f => f.Type is ExtensionFieldType.AudioClip)
+                .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
+                .ToArray();
+
+            var component = ext.GetComponent<WorldItemTemplateList>();
+
+            // コンポーネントが要らない場合、削除した状態を正とする
+            if (entries.Length == 0)
+            {
+                if (component != null)
+                {
+                    Object.DestroyImmediate(component);
+                    EditorUtility.SetDirty(ext.gameObject);
+                }
+                return;
+            }
+
+            // 必要なら普通に追加
+            if (component == null)
+            {
+                component = ext.gameObject.AddComponent<WorldItemTemplateList>();
+            }
+
+            // public propertyがないので、シリアライズした内容ベースでリストを構築する
+            var so = new SerializedObject(component);
+            var entriesProperty = so.FindProperty("worldItemTemplates");
+            entriesProperty.ClearArray();
+            for (var i = 0; i < entries.Length; i++)
+            {
+                entriesProperty.InsertArrayElementAtIndex(i);
+                var elem = entriesProperty.GetArrayElementAtIndex(i);
+                elem.FindPropertyRelative("id").stringValue = entries[i].Id;
+                elem.FindPropertyRelative("worldItemTemplate").objectReferenceValue = entries[i].Item;
+            }
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs
@@ -10,7 +10,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ComponentUpdater
         public static void Update(ScriptableItemExtension ext)
         {
             var entries = ext.ExtensionFields
-                .Where(f => f.Type is ExtensionFieldType.WorldItemTemplate)
+                .Where(f => f.Type is ExtensionFieldType.WorldItemTemplate && f.ItemReferenceValue != null)
                 .Select(f => (Id: f.FieldName, Item: f.ItemReferenceValue))
                 .ToArray();
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ComponentUpdater/WorldItemTemplateListUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2729605540496f0439a8e6e87adcb442
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e12909838d889e942ac2b241cd8a46de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/AssetReferenceDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/AssetReferenceDrawer.cs
@@ -1,0 +1,81 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.Inspector.ExtensionFieldDrawer
+{
+    using static FieldDrawerUtils;
+
+    /// <summary>
+    /// AnimationClipなどのアセット参照を表示する実装。
+    /// 個別コンポーネントのエラーチェックなども含んでいるので、
+    /// 分岐を細分化したい場合はそれをアセットの種類別に細分化してもよい
+    /// </summary>
+    public class AssetReferenceDrawer : IExtensionFieldDrawer
+    {
+        public int Priority => 1;
+
+        public bool CanDraw(SerializedProperty property, ExtensionFieldType type)
+        {
+            return (int)type >= (int)ExtensionFieldType.AssetReferenceIndexOffset;
+        }
+
+        public float GetPropertyHeight(SerializedProperty property, ExtensionFieldType type)
+        {
+            return LineHeight(1f);
+        }
+
+        public void Draw(Rect position, SerializedProperty property, ExtensionFieldType type)
+        {
+            var valueProperty = type switch
+            {
+                ExtensionFieldType.AudioClip => property.FindPropertyRelative("audioClipValue"),
+                ExtensionFieldType.HumanoidAnimation => property.FindPropertyRelative("humanoidAnimationClipValue"),
+                ExtensionFieldType.WorldItem => property.FindPropertyRelative("itemReferenceValue"),
+                ExtensionFieldType.WorldItemTemplate => property.FindPropertyRelative("itemReferenceValue"),
+                ExtensionFieldType.Material => property.FindPropertyRelative("materialValue"),
+                _ => null,
+            };
+
+            if (valueProperty == null)
+            {
+                // CanDrawで弾いてるから通常は来ないはず
+                EditorGUILayout.LabelField("(error: unsupported type!)");
+                return;
+            }
+            
+            position.height = LineHeight(1f);
+            
+            var fieldName = GetFieldName(property);
+            EditorGUI.PropertyField(position, valueProperty, new GUIContent(fieldName));
+
+            // AudioClipでは他と違ってループの有無も設定が必要なので、それを表示する
+            if (type is ExtensionFieldType.AudioClip)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(
+                    property.FindPropertyRelative("boolValue"),
+                    new GUIContent(fieldName + ": loop")
+                );
+                EditorGUI.indentLevel--;
+            }
+            
+            if (type is ExtensionFieldType.HumanoidAnimation)
+            {
+                CheckErrorForHumanoidAnimation(valueProperty);
+            }
+        }
+
+        void CheckErrorForHumanoidAnimation(SerializedProperty valueProperty)
+        {
+            if (valueProperty.objectReferenceValue is AnimationClip clip && !clip.isHumanMotion)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.LabelField(
+                    "Error: The clip seems not Humanoid Animation!", 
+                    (GUIStyle) "CN StatusWarn"
+                );
+                EditorGUI.indentLevel--;
+            }
+        }
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/AssetReferenceDrawer.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/AssetReferenceDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48cd7b2029a10da40b0cb720b8581a10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/OverridablePrimitiveDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/OverridablePrimitiveDrawer.cs
@@ -1,0 +1,88 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.Inspector.ExtensionFieldDrawer
+{
+    using static FieldDrawerUtils;
+
+    /// <summary>
+    /// 数値などの基本的なプリミティブに対し、オーバーライドの有無と値のカスタムUIの2つを提示する実装
+    /// </summary>
+    public class OverridablePrimitiveDrawer : IExtensionFieldDrawer
+    {
+        public int Priority => 0;
+        
+        public bool CanDraw(SerializedProperty property, ExtensionFieldType type)
+        {
+            //NOTE: 暗黙に、このプロパティより
+            return (int)type < (int)ExtensionFieldType.AssetReferenceIndexOffset;
+        }
+
+        public float GetPropertyHeight(SerializedProperty property, ExtensionFieldType type)
+        {
+            return LineHeight(2f);
+        }
+
+        public void Draw(Rect position, SerializedProperty property, ExtensionFieldType type)
+        {
+            ShowOverrideBoolValueProperty(position, property);
+            
+            var valueProperty = type switch
+            {
+                ExtensionFieldType.Bool => property.FindPropertyRelative("boolValue"),
+                ExtensionFieldType.Int => property.FindPropertyRelative("intValue"),
+                ExtensionFieldType.Float => property.FindPropertyRelative("floatValue"),
+                ExtensionFieldType.String => property.FindPropertyRelative("stringValue"),
+                ExtensionFieldType.Vector2 => property.FindPropertyRelative("vector2Value"),
+                ExtensionFieldType.Vector3 => property.FindPropertyRelative("vector3Value"),
+                ExtensionFieldType.Quaternion => property.FindPropertyRelative("quaternionValue"),
+                _ => null,
+            };
+
+            if (valueProperty == null)
+            {
+                // CanDrawで弾いてるから通常は来ないはず
+                EditorGUILayout.LabelField("(error: unsupported type!)");
+                return;
+            }
+
+            EditorGUI.BeginDisabledGroup(!IsOverrideActive(property));
+
+            position.y += LineHeight(1f);
+            position.height = LineHeight(1f);
+            
+            var fieldName = GetFieldName(property);
+            var fieldLabel = new GUIContent(fieldName);
+            
+            // Sliderを表示する場合もUIの高さは据え置きなので、だいたい同等に扱う
+            var hasRange = property.FindPropertyRelative("hasRange").boolValue;
+            if (type is ExtensionFieldType.Int && hasRange)
+            {
+                EditorGUI.IntSlider(
+                    position,
+                    valueProperty,
+                    (int)property.FindPropertyRelative("rangeMin").floatValue,
+                    (int)property.FindPropertyRelative("rangeMax").floatValue,
+                    fieldLabel
+                );
+            }
+            else if (type is ExtensionFieldType.Float && hasRange)
+            {
+                EditorGUI.Slider(
+                    position,
+                    valueProperty,
+                    property.FindPropertyRelative("rangeMin").floatValue,
+                    property.FindPropertyRelative("rangeMax").floatValue,
+                    fieldLabel
+                );
+            }
+            else
+            {
+                EditorGUI.PropertyField(position, valueProperty, fieldLabel);
+            }
+            
+            EditorGUI.EndDisabledGroup();
+        }
+    }
+}
+

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/OverridablePrimitiveDrawer.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/OverridablePrimitiveDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e227227888fac34cae44d0213716adf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/TextAreaStringDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/TextAreaStringDrawer.cs
@@ -1,0 +1,66 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.Inspector.ExtensionFieldDrawer
+{
+    using static FieldDrawerUtils;
+
+    /// <summary>
+    /// 複数行を表示して編集できるような文字列プロパティを提示する
+    /// </summary>
+    public class TextAreaStringDrawer : IExtensionFieldDrawer
+    {
+        private const float HeightFactor = 2f;
+        private const float ScrollAreaHeightFactor = 3.5f;
+        private Vector2 scrollPosition = Vector2.zero;
+
+        public int Priority => 10;
+
+        public bool CanDraw(SerializedProperty property, ExtensionFieldType type)
+        {
+            return type is ExtensionFieldType.String &&
+                property.FindPropertyRelative("useTextArea").boolValue;
+        }
+
+        public float GetPropertyHeight(SerializedProperty property, ExtensionFieldType type)
+        {
+            return LineHeight(HeightFactor);
+        }
+
+        public void Draw(Rect position, SerializedProperty property, ExtensionFieldType type)
+        {
+            // 見え方としては overrideの有無、フィールド名、TextAreaフィールドがこの順に表示される
+            //   foo: override
+            //   foo
+            //   [    ]
+            //   [    ]
+            //   [    ]
+            
+            ShowOverrideBoolValueProperty(position, property);
+
+            var singleLineHeight = LineHeight(1f);
+            position.y += singleLineHeight;
+            position.height = singleLineHeight;
+            var fieldName = GetFieldName(property);
+            EditorGUI.LabelField(position, fieldName);
+
+            EditorGUI.BeginDisabledGroup(!IsOverrideActive(property));
+            
+            //NOTE: ラベルとテキストエリアの間の隙間が広すぎるのを調整している
+            //EditorGUILayout.Space(-10);
+            scrollPosition = EditorGUILayout.BeginScrollView(
+                scrollPosition,
+                GUILayout.Height(LineHeight(ScrollAreaHeightFactor))
+            );
+
+            var valueProperty = property.FindPropertyRelative("stringValue");
+            valueProperty.stringValue = EditorGUILayout.TextArea(
+                valueProperty.stringValue,
+                GUILayout.ExpandHeight(true)
+            );
+            EditorGUILayout.EndScrollView();
+            
+            EditorGUI.EndDisabledGroup();
+        }
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/TextAreaStringDrawer.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ExtensionFieldDrawer/TextAreaStringDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b529746b04ebb1a47915e0ef9464cd82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs
@@ -1,0 +1,44 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.Inspector
+{
+    /// <summary>
+    /// <see cref="ScriptableItemExtension"/>のフィールド値のプロパティ描画するときに使うサブルーチン。
+    /// </summary>
+    public static class FieldDrawerUtils
+    {
+        /// <summary>
+        /// インスペクターの1行あたりの高さに倍率をかけた高さを取得する。
+        /// </summary>
+        /// <param name="factor"></param>
+        /// <returns></returns>
+        public static float LineHeight(float factor)
+            => EditorGUIUtility.singleLineHeight * factor;
+        
+        /// <summary>
+        /// フィールド名を取得する。
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        public static string GetFieldName(SerializedProperty property)
+            => property.FindPropertyRelative("fieldName").stringValue;
+
+        /// <summary>
+        /// overrideの有無をプロパティとして表示する。
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="property"></param>
+        public static void ShowOverrideBoolValueProperty(Rect position, SerializedProperty property)
+        {
+            var fieldName = GetFieldName(property);
+            var pos = position;
+            pos.height = LineHeight(1f);
+            var prop = property.FindPropertyRelative("overrideValue");
+            EditorGUI.PropertyField(pos, prop, new GUIContent(fieldName + ": override"));
+        }
+        
+        public static bool IsOverrideActive(SerializedProperty property)
+            => property.FindPropertyRelative("overrideValue").boolValue;
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs
@@ -40,5 +40,8 @@ namespace Baxter.ClusterScriptExtensions.Editor.Inspector
         
         public static bool IsOverrideActive(SerializedProperty property)
             => property.FindPropertyRelative("overrideValue").boolValue;
+
+        public static void ShowWarning(string message) 
+            => EditorGUILayout.LabelField(message, (GUIStyle) "CN StatusWarn");
     }
 }

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/FieldDrawerUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d65c4c4f047c4534590310dbc97d60d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/IExtensionFieldDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/IExtensionFieldDrawer.cs
@@ -1,0 +1,43 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Baxter.ClusterScriptExtensions.Editor.Inspector
+{
+    public interface IExtensionFieldDrawer
+    {
+        /// <summary>
+        /// この値が大きいほど、優先的に<see cref="CanDraw"/>や<see cref="Draw"/>が呼ばれる。
+        /// 特殊な条件のプロパティ描画を行いたいI/F実装では大きめの値を返し、
+        /// フォールバック的な汎用の描画を行うI/F実装では小さめの値を返す。
+        /// </summary>
+        int Priority { get; }
+        
+        /// <summary>
+        /// 指定したプロパティをこのI/F実装が描画できるかどうかを判定する。
+        /// trueを返した場合、<see cref="GetPropertyHeight"/>と<see cref="Draw"/>が呼ばれる
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        bool CanDraw(SerializedProperty property, ExtensionFieldType type);
+
+        /// <summary>
+        /// 指定したプロパティの描画高さを取得する。
+        /// 呼び出し元は <see cref="CanDraw"/> trueになるようなプロパティでのみ、このメソッドを呼ぶ
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        float GetPropertyHeight(SerializedProperty property, ExtensionFieldType type);
+
+        /// <summary>
+        /// 指定したプロパティを描画する。
+        /// 呼び出し元は <see cref="CanDraw"/> trueになるようなプロパティでのみ、このメソッドを呼ぶ
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="property"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        void Draw(Rect position, SerializedProperty property, ExtensionFieldType type);
+    }
+}

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/IExtensionFieldDrawer.cs.meta
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/IExtensionFieldDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58eaf4b9bfe096848be0bd135d24328d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionEditor.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionEditor.cs
@@ -27,6 +27,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.Inspector
             for (var i = 0; i < size; i++)
             {
                 EditorGUILayout.PropertyField(fieldsProperty.GetArrayElementAtIndex(i));
+                EditorGUILayout.Space();
             }
             EditorGUI.indentLevel--;
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionFieldDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionFieldDrawer.cs
@@ -78,6 +78,9 @@ namespace Baxter.ClusterScriptExtensions.Editor.Inspector
             var valueProperty = fieldType switch
             {
                 ExtensionFieldType.HumanoidAnimation => property.FindPropertyRelative("humanoidAnimationClipValue"),
+                ExtensionFieldType.WorldItem => property.FindPropertyRelative("itemReferenceValue"),
+                ExtensionFieldType.WorldItemTemplate => property.FindPropertyRelative("itemReferenceValue"),
+                ExtensionFieldType.Material => property.FindPropertyRelative("materialValue"),
                 _ => null,
             };
 

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionFieldDrawer.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/Inspector/ScriptableItemExtensionFieldDrawer.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Baxter.ClusterScriptExtensions.Editor.Inspector.ExtensionFieldDrawer;
 using UnityEditor;
 using UnityEngine;
 
@@ -6,212 +8,52 @@ namespace Baxter.ClusterScriptExtensions.Editor.Inspector
     [CustomPropertyDrawer(typeof(ScriptExtensionField))]
     public class ScriptExtensionFieldDrawer : PropertyDrawer
     {
-        private const float TextAreaTotalLineHeightFactor = 6f;
-        private const float LineHeightFactor = 2.5f;
-        private const float AudioClipLineHeightFactor = 2.5f;
-        private const float AssetReferenceLineHeightFactor = 1.5f;
-        private const float TextAreaLineHeightFactor = TextAreaTotalLineHeightFactor - LineHeightFactor;
+        static ScriptExtensionFieldDrawer()
+        {
+            var drawers = new IExtensionFieldDrawer[]
+            {
+                new TextAreaStringDrawer(),
+                new AssetReferenceDrawer(),
+                new OverridablePrimitiveDrawer(),
+            };
 
-        private Vector2 textAreaScrollPosition;
-        
+            Drawers = drawers.OrderByDescending(d => d.Priority).ToArray();
+        }
+
+        // NOTE: 
+        private static readonly IExtensionFieldDrawer[] Drawers;
+
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             var fieldType = GetFieldType(property);
-            if (fieldType is ExtensionFieldType.AudioClip)
+            foreach (var drawer in Drawers)
             {
-                return LineHeight(AudioClipLineHeightFactor);
+                if (drawer.CanDraw(property, fieldType))
+                {
+                    return drawer.GetPropertyHeight(property, fieldType);
+                }
             }
-            else if ((int)fieldType >= (int)ExtensionFieldType.AssetReferenceIndexOffset)
-            {
-                return LineHeight(AssetReferenceLineHeightFactor);
-            }
-            else if (UseTextArea(property))
-            {
-                return LineHeight(LineHeightFactor);
-            }
-            else
-            {
-                return LineHeight(LineHeightFactor);
-            }
+
+            // NOTE: エラー表示はEditorGUILayoutで行うため、高さを確保する必要がない
+            return 0f;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             var fieldType = GetFieldType(property);
-            if (fieldType is ExtensionFieldType.AudioClip)
+            foreach (var drawer in Drawers)
             {
-                OnGUIWithAudioClipProperty(position, property);
-            }
-            else if ((int)fieldType >= (int)ExtensionFieldType.AssetReferenceIndexOffset)
-            {
-                OnGUIWithAssetReferenceProperty(position, property);
-            }
-            else
-            {
-                OnGUIWithOverridableProperty(position, property);
-            }
-        }
-
-        // NOTE: AudioClipは通常のAssetReferenceと違い、loopフラグを提示する
-        private void OnGUIWithAudioClipProperty(Rect position, SerializedProperty property)
-        {
-            var fieldName = property.FindPropertyRelative("fieldName").stringValue;
-            var label = new GUIContent(fieldName);
-            var loopLabel = new GUIContent(fieldName + ": loop");
-            
-            var valueProperty = property.FindPropertyRelative("audioClipValue");
-            var loopProperty = property.FindPropertyRelative("boolValue");
-
-            position.height = LineHeight(1f);
-            EditorGUI.PropertyField(position, valueProperty, label);
-
-            position.y += LineHeight(1f);
-            EditorGUI.PropertyField(position, loopProperty, loopLabel);
-        }
-        
-        private void OnGUIWithAssetReferenceProperty(Rect position, SerializedProperty property)
-        {
-            position.y += LineHeight(0.5f);
-            var fieldName = property.FindPropertyRelative("fieldName").stringValue;
-            var fieldType = (ExtensionFieldType)property.FindPropertyRelative("type").intValue;
-            var label = new GUIContent(fieldName);
-            var valueProperty = fieldType switch
-            {
-                ExtensionFieldType.HumanoidAnimation => property.FindPropertyRelative("humanoidAnimationClipValue"),
-                ExtensionFieldType.WorldItem => property.FindPropertyRelative("itemReferenceValue"),
-                ExtensionFieldType.WorldItemTemplate => property.FindPropertyRelative("itemReferenceValue"),
-                ExtensionFieldType.Material => property.FindPropertyRelative("materialValue"),
-                _ => null,
-            };
-
-            if (valueProperty == null)
-            {
-                EditorGUILayout.LabelField("(error: unsupported type!)");
-                return;
-            }
-
-            position.height = LineHeight(1f);
-            EditorGUI.PropertyField(position, valueProperty, label);
-
-            if (fieldType is ExtensionFieldType.HumanoidAnimation &&
-                valueProperty.objectReferenceValue is AnimationClip clip &&
-                !clip.isHumanMotion)
-            {
-                EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField(
-                    "Error: The clip seems not Humanoid Animation!", 
-                    (GUIStyle) "CN StatusWarn"
-                    );
-                EditorGUI.indentLevel--;
-            }
-        }
-
-        private void OnGUIWithOverridableProperty(Rect position, SerializedProperty property)
-        {
-            // 「overrideするかどうか + overrideする対象の値」みたいな見え方にする。
-            // foo: override   [x]
-            // foo             [  42  ]
-            var fieldName = property.FindPropertyRelative("fieldName").stringValue;
-
-            var overrideValuePos = position;
-            overrideValuePos.height = LineHeight(1f);
-            var overrideValueProperty = property.FindPropertyRelative("overrideValue");
-            EditorGUI.PropertyField(overrideValuePos, overrideValueProperty, new GUIContent(fieldName + ": override"));
-
-            var useTextArea = UseTextArea(property);
-            
-            var propertyPosition = position;
-            propertyPosition.y = position.y + LineHeight(1f);
-            propertyPosition.height = LineHeight(1f);
-
-            // textAreaを使う場合、ラベルだけ書いて下にずらす
-            if (useTextArea)
-            {
-                EditorGUI.LabelField(propertyPosition, fieldName);
-                propertyPosition.y += LineHeight(1f);
-                propertyPosition.height = LineHeight(TextAreaLineHeightFactor);
+                if (drawer.CanDraw(property, fieldType))
+                {
+                    drawer.Draw(position, property, fieldType);
+                    return;
+                }
             }
             
-            var type = (ExtensionFieldType)property.FindPropertyRelative("type").intValue;
-            var valueProperty = type switch
-            {
-                ExtensionFieldType.Bool => property.FindPropertyRelative("boolValue"),
-                ExtensionFieldType.Int => property.FindPropertyRelative("intValue"),
-                ExtensionFieldType.Float => property.FindPropertyRelative("floatValue"),
-                ExtensionFieldType.String => property.FindPropertyRelative("stringValue"),
-                ExtensionFieldType.Vector2 => property.FindPropertyRelative("vector2Value"),
-                ExtensionFieldType.Vector3 => property.FindPropertyRelative("vector3Value"),
-                ExtensionFieldType.Quaternion => property.FindPropertyRelative("quaternionValue"),
-                _ => null,
-            };
-
-            if (valueProperty == null)
-            {
-                EditorGUILayout.LabelField("(error: unsupported type!)");
-                return;
-            }
-            
-            EditorGUI.BeginDisabledGroup(!overrideValueProperty.boolValue);
-
-            var fieldLabel = new GUIContent(fieldName);
-
-            if (type is ExtensionFieldType.Int &&
-                property.FindPropertyRelative("hasRange").boolValue)
-            {
-                EditorGUI.IntSlider(
-                    propertyPosition,
-                    valueProperty,
-                    (int)property.FindPropertyRelative("rangeMin").floatValue,
-                    (int)property.FindPropertyRelative("rangeMax").floatValue,
-                    fieldLabel
-                );
-            }
-            else if (
-                type is ExtensionFieldType.Float &&
-                property.FindPropertyRelative("hasRange").boolValue)
-            {
-                EditorGUI.Slider(
-                    propertyPosition,
-                    valueProperty,
-                    property.FindPropertyRelative("rangeMin").floatValue,
-                    property.FindPropertyRelative("rangeMax").floatValue,
-                    fieldLabel
-                );
-            }
-            else if (useTextArea)
-            {
-                //NOTE: ラベルとテキストエリアの間の隙間が広すぎるのを調整している
-                EditorGUILayout.Space(-10);
-                textAreaScrollPosition = EditorGUILayout.BeginScrollView(
-                    textAreaScrollPosition,
-                    GUILayout.Height(propertyPosition.height)
-                );
-                valueProperty.stringValue = EditorGUILayout.TextArea(
-                    valueProperty.stringValue,
-                    GUILayout.ExpandHeight(true)
-                );
-                EditorGUILayout.EndScrollView();
-                EditorGUILayout.Space();
-            }
-            else
-            {
-                EditorGUI.PropertyField(propertyPosition, valueProperty, fieldLabel);
-            }
-            
-            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.LabelField("(error: unsupported type!)");
         }
 
         private static ExtensionFieldType GetFieldType(SerializedProperty property)
             => (ExtensionFieldType)property.FindPropertyRelative("type").intValue;
-        
-        private static bool UseTextArea(SerializedProperty property)
-        {
-            var type = (ExtensionFieldType)property.FindPropertyRelative("type").intValue;
-            return
-                type is ExtensionFieldType.String &&
-                property.FindPropertyRelative("useTextArea").boolValue;
-        }
-        
-        private static float LineHeight(float factor) => EditorGUIUtility.singleLineHeight * factor;
     }
 }

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptParser/ExtensionFieldParser.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptParser/ExtensionFieldParser.cs
@@ -68,6 +68,8 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptParser
             ["vector2"] = ExtensionFieldType.Vector2,
             ["vector3"] = ExtensionFieldType.Vector3,
             ["quaternion"] = ExtensionFieldType.Quaternion,
+            ["audioclip"] = ExtensionFieldType.AudioClip,
+            ["humanoidanimation"] = ExtensionFieldType.HumanoidAnimation,
         };
 
         // 対象フィールドの検出条件
@@ -182,6 +184,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptParser
 
         private static void ApplyInitialValue(ScriptExtensionField target, Expression expr)
         {
+            //NOTE: アセット参照の型に対しては何もしないでOK (既定値は常にnullにしてよい)
             target.ResetInitialValues();
             switch (target.Type)
             {

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptParser/ExtensionFieldParser.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptParser/ExtensionFieldParser.cs
@@ -70,6 +70,9 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptParser
             ["quaternion"] = ExtensionFieldType.Quaternion,
             ["audioclip"] = ExtensionFieldType.AudioClip,
             ["humanoidanimation"] = ExtensionFieldType.HumanoidAnimation,
+            ["worlditem"] = ExtensionFieldType.WorldItem,
+            ["worlditemtemplate"] = ExtensionFieldType.WorldItemTemplate,
+            ["material"] = ExtensionFieldType.Material,
         };
 
         // 対象フィールドの検出条件

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptUpdater/ItemScriptUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptUpdater/ItemScriptUpdater.cs
@@ -38,6 +38,9 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptUpdater
             
             ItemAudioSetListUpdater.Update(ext);
             HumanoidAnimationListUpdater.Update(ext);
+            WorldItemReferenceListUpdater.Update(ext);
+            WorldItemTemplateListUpdater.Update(ext);
+            ItemMaterialSetListUpdater.Update(ext);
         }
         
         // 指定された位置のコードを消して別のテキストに置き換えたスクリプト文字列を生成する。

--- a/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptUpdater/ItemScriptUpdater.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Editor/ScriptUpdater/ItemScriptUpdater.cs
@@ -1,4 +1,5 @@
 using System;
+using Baxter.ClusterScriptExtensions.Editor.ComponentUpdater;
 using ClusterVR.CreatorKit.Item.Implements;
 using UnityEditor;
 
@@ -11,7 +12,7 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptUpdater
     {
         /// <summary>
         /// ScriptableItemExtensionの内容に基づいてソースコードを生成し、
-        /// ScriptableItemのテキストとして適用する
+        /// ScriptableItemのテキストとして適用する。また、そのときアセットの参照状況も適用する
         /// </summary>
         /// <param name="ext"></param>
         public static void ApplyGeneratedSourceCode(ScriptableItemExtension ext)
@@ -34,6 +35,9 @@ namespace Baxter.ClusterScriptExtensions.Editor.ScriptUpdater
             var sourceCodeProperty = serializedTarget.FindProperty("sourceCode");
             sourceCodeProperty.stringValue = script;
             serializedTarget.ApplyModifiedProperties();
+            
+            ItemAudioSetListUpdater.Update(ext);
+            HumanoidAnimationListUpdater.Update(ext);
         }
         
         // 指定された位置のコードを消して別のテキストに置き換えたスクリプト文字列を生成する。

--- a/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
@@ -32,6 +32,7 @@ namespace Baxter.ClusterScriptExtensions
         [SerializeField] private Vector2 vector2InitialValue;
         [SerializeField] private Vector3 vector3InitialValue;
         [SerializeField] private Quaternion quaternionInitialValue;
+        //NOTE: Asset参照系は初期値がない(常にnull)
         
         // Inspectorで編集するのはここから下の部分
         
@@ -45,6 +46,8 @@ namespace Baxter.ClusterScriptExtensions
         [SerializeField] private Vector2 vector2Value;
         [SerializeField] private Vector3 vector3Value;
         [SerializeField] private Quaternion quaternionValue;
+        [SerializeField] private AudioClip audioClipValue;
+        [SerializeField] private AnimationClip humanoidAnimationClipValue;
  
         #region Meta Properties
 
@@ -136,6 +139,13 @@ namespace Baxter.ClusterScriptExtensions
             set => quaternionInitialValue = value;
         }
 
+        //HACK: field自体がbool値のケースではなく、Audioのループフラグとして転用しているときにフラグを外から使うことがある
+        public bool BoolValue => boolValue;
+
+        //NOTE: アセット参照系のものは初期値がnullなので、overrideと関係なく実際にアサインされた値を正とする
+        public AudioClip AudioClipValue => audioClipValue;
+        public AnimationClip HumanoidAnimationClipValue => humanoidAnimationClipValue;
+        
         private bool ActiveBoolValue => overrideValue ? boolValue : boolInitialValue;
         private int ActiveIntValue => overrideValue ? intValue : intInitialValue;
         private float ActiveFloatValue => overrideValue ? floatValue : floatInitialValue;
@@ -162,6 +172,8 @@ namespace Baxter.ClusterScriptExtensions
                     => $"new Vector3({ActiveVector3Value.x:G}, {ActiveVector3Value.y:G}, {ActiveVector3Value.z:G})",
                 ExtensionFieldType.Quaternion
                     => $"new Quaternion({ActiveQuaternionValue.x:G}, {ActiveQuaternionValue.y:G}, {ActiveQuaternionValue.z:G}, {ActiveQuaternionValue.w:G})",
+                ExtensionFieldType.AudioClip => $"$.audio(\"{fieldName}\")",
+                ExtensionFieldType.HumanoidAnimation => $"$.humanoidAnimation(\"{fieldName}\")",
                 _ => throw new InvalidOperationException("Unsupported type!"),
             };
         }
@@ -192,6 +204,8 @@ namespace Baxter.ClusterScriptExtensions
             vector2Value = source.vector2Value;
             vector3Value = source.vector3Value;
             quaternionValue = source.quaternionValue;
+            audioClipValue = source.audioClipValue;
+            humanoidAnimationClipValue = source.humanoidAnimationClipValue;
         }
         
         public void ResetValues()
@@ -204,6 +218,8 @@ namespace Baxter.ClusterScriptExtensions
             vector2Value = vector2InitialValue;
             vector3Value = vector3InitialValue;
             quaternionValue = quaternionInitialValue;
+            audioClipValue = null;
+            humanoidAnimationClipValue = null;
         }
     }
 }

--- a/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
@@ -213,8 +213,11 @@ namespace Baxter.ClusterScriptExtensions
             vector2Value = source.vector2Value;
             vector3Value = source.vector3Value;
             quaternionValue = source.quaternionValue;
+
             audioClipValue = source.audioClipValue;
             humanoidAnimationClipValue = source.humanoidAnimationClipValue;
+            itemReferenceValue = source.itemReferenceValue;
+            materialValue = source.materialValue;
         }
         
         public void ResetValues()
@@ -227,8 +230,11 @@ namespace Baxter.ClusterScriptExtensions
             vector2Value = vector2InitialValue;
             vector3Value = vector3InitialValue;
             quaternionValue = quaternionInitialValue;
+
             audioClipValue = null;
             humanoidAnimationClipValue = null;
+            itemReferenceValue = null;
+            materialValue = null;
         }
     }
 }

--- a/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionField.cs
@@ -1,4 +1,5 @@
 using System;
+using ClusterVR.CreatorKit.Item.Implements;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -48,7 +49,10 @@ namespace Baxter.ClusterScriptExtensions
         [SerializeField] private Quaternion quaternionValue;
         [SerializeField] private AudioClip audioClipValue;
         [SerializeField] private AnimationClip humanoidAnimationClipValue;
- 
+        // NOTE: fieldTypeによってシーン上アイテムを指す場合とprefabを指す場合がある
+        [SerializeField] private Item itemReferenceValue;
+        [SerializeField] private Material materialValue;
+
         #region Meta Properties
 
         public bool HasRange
@@ -145,6 +149,8 @@ namespace Baxter.ClusterScriptExtensions
         //NOTE: アセット参照系のものは初期値がnullなので、overrideと関係なく実際にアサインされた値を正とする
         public AudioClip AudioClipValue => audioClipValue;
         public AnimationClip HumanoidAnimationClipValue => humanoidAnimationClipValue;
+        public Item ItemReferenceValue => itemReferenceValue;
+        public Material MaterialValue => materialValue;
         
         private bool ActiveBoolValue => overrideValue ? boolValue : boolInitialValue;
         private int ActiveIntValue => overrideValue ? intValue : intInitialValue;
@@ -174,6 +180,9 @@ namespace Baxter.ClusterScriptExtensions
                     => $"new Quaternion({ActiveQuaternionValue.x:G}, {ActiveQuaternionValue.y:G}, {ActiveQuaternionValue.z:G}, {ActiveQuaternionValue.w:G})",
                 ExtensionFieldType.AudioClip => $"$.audio(\"{fieldName}\")",
                 ExtensionFieldType.HumanoidAnimation => $"$.humanoidAnimation(\"{fieldName}\")",
+                ExtensionFieldType.WorldItem => $"$.worldItemReference(\"{fieldName}\")",
+                ExtensionFieldType.WorldItemTemplate => $"new WorldItemTemplateId(\"{fieldName}\")",
+                ExtensionFieldType.Material => $"$.material(\"{fieldName}\")",
                 _ => throw new InvalidOperationException("Unsupported type!"),
             };
         }

--- a/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionFieldType.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionFieldType.cs
@@ -16,6 +16,8 @@ namespace Baxter.ClusterScriptExtensions
 
         // もしアセット参照にかかわるField (WorldItemReferenceなど) を追加する場合、
         // オフセットをつけて分割する: プリミティブと混ざるとややこしいため
-        //AssetReferenceIndexOffset = 1000,
+        AssetReferenceIndexOffset = 1000,
+        AudioClip,
+        HumanoidAnimation,
     }
 }

--- a/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionFieldType.cs
+++ b/Assets/Baxter/ClusterScriptExtensions/Runtime/Data/ScriptExtensionFieldType.cs
@@ -19,5 +19,8 @@ namespace Baxter.ClusterScriptExtensions
         AssetReferenceIndexOffset = 1000,
         AudioClip,
         HumanoidAnimation,
+        WorldItem,
+        WorldItemTemplate,
+        Material,
     }
 }

--- a/Assets/Internal/Animations.meta
+++ b/Assets/Internal/Animations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df5bd2ebc9f82b4479e53ded068c1d8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Internal/Animations/EmptyGenericAnimation.anim
+++ b/Assets/Internal/Animations/EmptyGenericAnimation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EmptyGenericAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Internal/Animations/EmptyGenericAnimation.anim.meta
+++ b/Assets/Internal/Animations/EmptyGenericAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7bcb85b2341ba34bbbab86a34cf9749
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js
+++ b/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js
@@ -4,6 +4,16 @@ const myAudio = $.audio("");
 // @field(HumanoidAnimation)
 const myMotion = $.humanoidAnimation("");
 
+// @field(WorldItem)
+const otherItemInstance = $.worldItemReference("");
+
+// @field(WorldItemTemplate)
+const creatableItem = new WorldItemTemplateId("");
+
+// @field(Material)
+const myRendererMaterial = $.material("");
+
+
 $.onInteract(() => { 
   $.log("try play audio...");
   myAudio.play();

--- a/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js
+++ b/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js
@@ -1,0 +1,10 @@
+// @field(AudioClip)
+const myAudio = $.audio("");
+
+// @field(HumanoidAnimation)
+const myMotion = $.humanoidAnimation("");
+
+$.onInteract(() => { 
+  $.log("try play audio...");
+  myAudio.play();
+});

--- a/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js.meta
+++ b/Assets/Internal/ClusterScripts/Item/Sample05_AssetReferences.js.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 0c2596e0e5a86804b8564022ca36b546
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: ee543661da8734b3b8b03e99d421098e, type: 3}

--- a/Assets/Internal/Materials/MaterialExample.mat
+++ b/Assets/Internal/Materials/MaterialExample.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MaterialExample
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Internal/Materials/MaterialExample.mat.meta
+++ b/Assets/Internal/Materials/MaterialExample.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1673944c63e89fd4f860310beb4951ae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Internal/Prefabs/PrefabModeExample_AssetReference.prefab
+++ b/Assets/Internal/Prefabs/PrefabModeExample_AssetReference.prefab
@@ -1,0 +1,532 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &241378221218274200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8088331295539597801}
+  - component: {fileID: 8045401360281383006}
+  - component: {fileID: 2847426589237151013}
+  - component: {fileID: 5801890222233364708}
+  - component: {fileID: 508139662913489358}
+  - component: {fileID: 4713488437139639650}
+  - component: {fileID: 4741236268019650573}
+  - component: {fileID: 8286971323409521180}
+  - component: {fileID: 633248824439090079}
+  - component: {fileID: 1855454855662543821}
+  - component: {fileID: 1623191389348562539}
+  - component: {fileID: 1365597436342849146}
+  m_Layer: 0
+  m_Name: MainItem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8088331295539597801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8546996133407889403}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8045401360281383006
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2847426589237151013
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5801890222233364708
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &508139662913489358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3977a5e65e72f4db4b85ddba10d48dd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  id:
+    value: 0
+  itemName: 
+  size: {x: 0, y: 0, z: 0}
+--- !u!114 &4713488437139639650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e61061896c654489a41575fc291bf4a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sourceCodeAsset: {fileID: 0}
+  sourceCode: "// @field(AudioClip)\r\nconst myAudio = $.audio(\"myAudio\");;\r\n\r\n//
+    @field(HumanoidAnimation)\r\nconst myMotion = $.humanoidAnimation(\"myMotion\");;\r\n\r\n//
+    @field(WorldItem)\r\nconst otherItemInstance = $.worldItemReference(\"otherItemInstance\");;\r\n\r\n//
+    @field(WorldItemTemplate)\r\nconst creatableItem = new WorldItemTemplateId(\"creatableItem\");;\r\n\r\n//
+    @field(Material)\r\nconst myRendererMaterial = $.material(\"myRendererMaterial\");;\r\n\r\n\r\n$.onInteract(()
+    => { \r\n  $.log(\"try play audio...\");\r\n  myAudio.play();\r\n});\r\n"
+--- !u!114 &4741236268019650573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b823bd601c25d6643a680126a20d89c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  templateCode: {fileID: 5022602860645237092, guid: 0c2596e0e5a86804b8564022ca36b546, type: 3}
+  extensionFields:
+  - fieldName: myAudio
+    type: 1001
+    fieldDefinedLocation:
+      startLine: 2
+      startColumn: 6
+      endLine: 2
+      endColumn: 27
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
+  - fieldName: myMotion
+    type: 1002
+    fieldDefinedLocation:
+      startLine: 5
+      startColumn: 6
+      endLine: 5
+      endColumn: 40
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
+  - fieldName: otherItemInstance
+    type: 1003
+    fieldDefinedLocation:
+      startLine: 8
+      startColumn: 6
+      endLine: 8
+      endColumn: 50
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 2710543769416635637}
+    materialValue: {fileID: 0}
+  - fieldName: creatableItem
+    type: 1004
+    fieldDefinedLocation:
+      startLine: 11
+      startColumn: 6
+      endLine: 11
+      endColumn: 49
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 1382718811334335605, guid: a52b08f9984dd4242be95c72566dd4b4, type: 3}
+    materialValue: {fileID: 0}
+  - fieldName: myRendererMaterial
+    type: 1005
+    fieldDefinedLocation:
+      startLine: 14
+      startColumn: 6
+      endLine: 14
+      endColumn: 41
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
+--- !u!114 &8286971323409521180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d598b4b653f4fba944e3077caab98f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemAudioSets:
+  - id: myAudio
+    audioClip: {fileID: 0}
+    loop: 0
+--- !u!114 &633248824439090079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff21d610f06941bd98a6fc9217c79607, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  humanoidAnimations:
+  - id: myMotion
+    animation: {fileID: 0}
+    humanoidAnimation: {fileID: 0}
+--- !u!114 &1855454855662543821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49554f6eafb04d538a589436719e8fa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  worldItemReferences:
+  - id: myAudio
+    item: {fileID: 0}
+--- !u!114 &1623191389348562539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02f60bfc9a2c4b04bcd3524b54a1e838, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  worldItemTemplates:
+  - id: myAudio
+    worldItemTemplate: {fileID: 0}
+    itemTemplateId:
+      value: 0
+--- !u!114 &1365597436342849146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 241378221218274200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62136917112e41e197a20e5b01fbb1cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemMaterialSets:
+  - id: myRendererMaterial
+    material: {fileID: 0}
+--- !u!1 &1468968863605464976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4010174148693104638}
+  - component: {fileID: 3906182124169637435}
+  - component: {fileID: 4374453587812859731}
+  - component: {fileID: 7382738146985760441}
+  - component: {fileID: 2710543769416635637}
+  m_Layer: 0
+  m_Name: OtherItem_InPrefabMode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4010174148693104638
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468968863605464976}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8546996133407889403}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3906182124169637435
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468968863605464976}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4374453587812859731
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468968863605464976}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7382738146985760441
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468968863605464976}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2710543769416635637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468968863605464976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3977a5e65e72f4db4b85ddba10d48dd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  id:
+    value: 0
+  itemName: 
+  size: {x: 0, y: 0, z: 0}
+--- !u!1 &8546996133407889402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8546996133407889403}
+  m_Layer: 0
+  m_Name: PrefabModeExample_AssetReference
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8546996133407889403
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8546996133407889402}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8088331295539597801}
+  - {fileID: 4010174148693104638}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Internal/Prefabs/PrefabModeExample_AssetReference.prefab.meta
+++ b/Assets/Internal/Prefabs/PrefabModeExample_AssetReference.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9c523678b54c1eb44825d51f5672ff9c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Internal/Prefabs/Sample02_Prefab_With_Gimmick.prefab
+++ b/Assets/Internal/Prefabs/Sample02_Prefab_With_Gimmick.prefab
@@ -152,6 +152,10 @@ MonoBehaviour:
       startColumn: 6
       endLine: 2
       endColumn: 23
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
     boolInitialValue: 0
     intInitialValue: 0
     floatInitialValue: 0
@@ -159,7 +163,7 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 1
+    overrideValue: 0
     boolValue: 0
     intValue: 0
     floatValue: 0
@@ -167,3 +171,7 @@ MonoBehaviour:
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}

--- a/Assets/Internal/Prefabs/Sample05_Prefab_Example.prefab
+++ b/Assets/Internal/Prefabs/Sample05_Prefab_Example.prefab
@@ -1,0 +1,116 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1382718811334335614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1382718811334335610}
+  - component: {fileID: 1382718811334335611}
+  - component: {fileID: 1382718811334335608}
+  - component: {fileID: 1382718811334335609}
+  - component: {fileID: 1382718811334335605}
+  m_Layer: 0
+  m_Name: Sample05_Prefab_Example
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1382718811334335610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382718811334335614}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1382718811334335611
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382718811334335614}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1382718811334335608
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382718811334335614}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &1382718811334335609
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382718811334335614}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1382718811334335605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382718811334335614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3977a5e65e72f4db4b85ddba10d48dd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  id:
+    value: 0
+  itemName: Sample05_Prefab
+  size: {x: 0, y: 0, z: 0}

--- a/Assets/Internal/Prefabs/Sample05_Prefab_Example.prefab.meta
+++ b/Assets/Internal/Prefabs/Sample05_Prefab_Example.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a52b08f9984dd4242be95c72566dd4b4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Internal/Scenes/TestScene.unity
+++ b/Assets/Internal/Scenes/TestScene.unity
@@ -448,6 +448,63 @@ Transform:
   m_Father: {fileID: 1411427678}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &345732283
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866279324507332140, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+      propertyPath: m_Name
+      value: Sample02_Prefab_With_Gimmick
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
 --- !u!1 &395168188
 GameObject:
   m_ObjectHideFlags: 0
@@ -588,6 +645,10 @@ MonoBehaviour:
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
 --- !u!114 &395168194
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -619,6 +680,103 @@ MonoBehaviour:
     value: 12967882894876145313
   itemName: Sample00_Hello
   size: {x: 0, y: 0, z: 0}
+--- !u!1 &712110324
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 712110325}
+  - component: {fileID: 712110328}
+  - component: {fileID: 712110327}
+  - component: {fileID: 712110326}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &712110325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712110324}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1792626625}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &712110326
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712110324}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &712110327
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712110324}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1673944c63e89fd4f860310beb4951ae, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &712110328
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712110324}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &942585007
 GameObject:
   m_ObjectHideFlags: 0
@@ -649,7 +807,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &942585009
 MonoBehaviour:
@@ -670,7 +828,7 @@ MonoBehaviour:
   myVector2: {x: 0, y: 0}
   myVector3: {x: 0, y: 0, z: 0}
   myRotation: {x: 0, y: 0, z: 0, w: 0}
-  myLongText: "\u3042\n\u3044\n\u3046\n\u3048"
+  myLongText: 
   myRangeInt: 0
   myRangeFloat: 1
   myEnumValue: 0
@@ -730,13 +888,17 @@ MonoBehaviour:
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
     overrideValue: 1
-    boolValue: 1
+    boolValue: 0
     intValue: 0
     floatValue: 0
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myInt
     type: 1
     fieldDefinedLocation:
@@ -757,12 +919,16 @@ MonoBehaviour:
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
     overrideValue: 1
     boolValue: 0
-    intValue: 23
+    intValue: 25
     floatValue: 0
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myFloat
     type: 2
     fieldDefinedLocation:
@@ -781,14 +947,18 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 1
+    overrideValue: 0
     boolValue: 0
     intValue: 0
-    floatValue: 4.5
+    floatValue: 12
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myString
     type: 3
     fieldDefinedLocation:
@@ -811,10 +981,14 @@ MonoBehaviour:
     boolValue: 0
     intValue: 0
     floatValue: 0
-    stringValue: TestABC
+    stringValue: aaa
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myVector2
     type: 4
     fieldDefinedLocation:
@@ -833,14 +1007,18 @@ MonoBehaviour:
     vector2InitialValue: {x: 1, y: 2}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 1
+    overrideValue: 0
     boolValue: 0
     intValue: 0
     floatValue: 0
     stringValue: 
-    vector2Value: {x: 3, y: 4}
+    vector2Value: {x: 6, y: 6}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myVector3
     type: 5
     fieldDefinedLocation:
@@ -859,7 +1037,7 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 3, y: 4, z: 5}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 0
+    overrideValue: 1
     boolValue: 0
     intValue: 0
     floatValue: 0
@@ -867,6 +1045,10 @@ MonoBehaviour:
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 5, y: 6, z: 7}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myQuaternion
     type: 6
     fieldDefinedLocation:
@@ -885,14 +1067,18 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 1
+    overrideValue: 0
     boolValue: 0
     intValue: 0
     floatValue: 0
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
-    quaternionValue: {x: 0.12767944, y: 0.14487815, z: 0.23929836, w: 0.9515485}
+    quaternionValue: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
 --- !u!114 &1043978764
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -906,15 +1092,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sourceCodeAsset: {fileID: 0}
-  sourceCode: "// @field(bool)\r\nconst myBool = true;;\r\n// @field(int)\r\nconst
-    myInt = 23;;\r\n// @field(float)\r\nconst myFloat = 4.5;;\r\n// @field(string)\r\nconst
-    myString = \"Test\";;\r\n// @field(Vector2)\r\nconst myVector2 = new Vector2(3,
-    4);;\r\n// @field(Vector3)\r\nconst myVector3 = new Vector3(3, 4, 5);;\r\n//
-    @field(Quaternion)\r\nconst myQuaternion = new Quaternion(0.1276794, 0.1448781,
-    0.2392984, 0.9515485);;\r\n\r\n$.onInteract(() => { \r\n  $.log(`myBool = ${myBool}`);\r\n 
-    $.log(`myInt = ${myInt}`);\r\n  $.log(`myFloat = ${myFloat}`);\r\n  $.log(`myString
-    = ${myString}`);\r\n  $.log(`myVector2 = ${myVector2}`);\r\n  $.log(`myVector3
-    = ${myVector3}`);\r\n  $.log(`myQuaternion = ${myQuaternion}`);\r\n});\r\n"
+  sourceCode: "// @field(bool)\r\nconst myBool = false;;\r\n// @field(int)\r\nconst
+    myInt = 25;;\r\n// @field(float)\r\nconst myFloat = 2.3;;\r\n// @field(string)\r\nconst
+    myString = \"Test\";;\r\n// @field(Vector2)\r\nconst myVector2 = new Vector2(1,
+    2);;\r\n// @field(Vector3)\r\nconst myVector3 = new Vector3(5, 6, 7);;\r\n//
+    @field(Quaternion)\r\nconst myQuaternion = new Quaternion(0, 0, 0, 1);;\r\n\r\n$.onInteract(()
+    => { \r\n  $.log(`myBool = ${myBool}`);\r\n  $.log(`myInt = ${myInt}`);\r\n 
+    $.log(`myFloat = ${myFloat}`);\r\n  $.log(`myString = ${myString}`);\r\n  $.log(`myVector2
+    = ${myVector2}`);\r\n  $.log(`myVector3 = ${myVector3}`);\r\n  $.log(`myQuaternion
+    = ${myQuaternion}`);\r\n});\r\n"
 --- !u!114 &1043978765
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1288,6 +1474,390 @@ MonoBehaviour:
     worldItemTemplate: {fileID: 4539557075613711507, guid: da0a31fd476111949b875c9a8a0b0a66, type: 3}
     itemTemplateId:
       value: 0
+--- !u!1 &1792626618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1792626625}
+  - component: {fileID: 1792626624}
+  - component: {fileID: 1792626623}
+  - component: {fileID: 1792626622}
+  - component: {fileID: 1792626621}
+  - component: {fileID: 1792626620}
+  - component: {fileID: 1792626619}
+  - component: {fileID: 1792626630}
+  - component: {fileID: 1792626629}
+  - component: {fileID: 1792626628}
+  - component: {fileID: 1792626627}
+  - component: {fileID: 1792626626}
+  m_Layer: 0
+  m_Name: Sample05_AssetReferences
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1792626619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b823bd601c25d6643a680126a20d89c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  templateCode: {fileID: 5022602860645237092, guid: 0c2596e0e5a86804b8564022ca36b546, type: 3}
+  extensionFields:
+  - fieldName: myAudio
+    type: 1001
+    fieldDefinedLocation:
+      startLine: 2
+      startColumn: 6
+      endLine: 2
+      endColumn: 27
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
+  - fieldName: myMotion
+    type: 1002
+    fieldDefinedLocation:
+      startLine: 5
+      startColumn: 6
+      endLine: 5
+      endColumn: 40
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
+  - fieldName: otherItemInstance
+    type: 1003
+    fieldDefinedLocation:
+      startLine: 8
+      startColumn: 6
+      endLine: 8
+      endColumn: 50
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 395168195}
+    materialValue: {fileID: 0}
+  - fieldName: creatableItem
+    type: 1004
+    fieldDefinedLocation:
+      startLine: 11
+      startColumn: 6
+      endLine: 11
+      endColumn: 49
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 1866279324507332143, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+    materialValue: {fileID: 0}
+  - fieldName: myRendererMaterial
+    type: 1005
+    fieldDefinedLocation:
+      startLine: 14
+      startColumn: 6
+      endLine: 14
+      endColumn: 41
+    hasRange: 0
+    rangeMin: 0
+    rangeMax: 0
+    useTextArea: 0
+    boolInitialValue: 0
+    intInitialValue: 0
+    floatInitialValue: 0
+    stringInitialValue: 
+    vector2InitialValue: {x: 0, y: 0}
+    vector3InitialValue: {x: 0, y: 0, z: 0}
+    quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
+    overrideValue: 0
+    boolValue: 0
+    intValue: 0
+    floatValue: 0
+    stringValue: 
+    vector2Value: {x: 0, y: 0}
+    vector3Value: {x: 0, y: 0, z: 0}
+    quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 2100000, guid: 1673944c63e89fd4f860310beb4951ae, type: 2}
+--- !u!114 &1792626620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e61061896c654489a41575fc291bf4a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sourceCodeAsset: {fileID: 0}
+  sourceCode: "// @field(AudioClip)\r\nconst myAudio = $.audio(\"myAudio\");;\r\n\r\n//
+    @field(HumanoidAnimation)\r\nconst myMotion = $.humanoidAnimation(\"myMotion\");;\r\n\r\n//
+    @field(WorldItem)\r\nconst otherItemInstance = $.worldItemReference(\"otherItemInstance\");;\r\n\r\n//
+    @field(WorldItemTemplate)\r\nconst creatableItem = new WorldItemTemplateId(\"creatableItem\");;\r\n\r\n//
+    @field(Material)\r\nconst myRendererMaterial = $.material(\"myRendererMaterial\");;\r\n\r\n\r\n$.onInteract(()
+    => { \r\n  $.log(\"try play audio...\");\r\n  myAudio.play();\r\n});\r\n"
+--- !u!114 &1792626621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3977a5e65e72f4db4b85ddba10d48dd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  id:
+    value: 0
+  itemName: 
+  size: {x: 0, y: 0, z: 0}
+--- !u!65 &1792626622
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1792626623
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 1896841071}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1792626624
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1792626625
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10, y: 0.5, z: 4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 712110325}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1792626626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62136917112e41e197a20e5b01fbb1cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemMaterialSets:
+  - id: myRendererMaterial
+    material: {fileID: 2100000, guid: 1673944c63e89fd4f860310beb4951ae, type: 2}
+--- !u!114 &1792626627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02f60bfc9a2c4b04bcd3524b54a1e838, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  worldItemTemplates:
+  - id: creatableItem
+    worldItemTemplate: {fileID: 1866279324507332143, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
+    itemTemplateId:
+      value: 0
+--- !u!114 &1792626628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49554f6eafb04d538a589436719e8fa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  worldItemReferences:
+  - id: otherItemInstance
+    item: {fileID: 395168195}
+--- !u!114 &1792626629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff21d610f06941bd98a6fc9217c79607, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  humanoidAnimations:
+  - id: myMotion
+    animation: {fileID: 0}
+    humanoidAnimation: {fileID: 0}
+--- !u!114 &1792626630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792626618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d598b4b653f4fba944e3077caab98f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemAudioSets:
+  - id: myAudio
+    audioClip: {fileID: 0}
+    loop: 0
 --- !u!1 &1815628113
 GameObject:
   m_ObjectHideFlags: 0
@@ -1382,6 +1952,98 @@ Transform:
   m_Father: {fileID: 95799366}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!21 &1896841071
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Default-Material (Instance)
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords:
+  - _EMISSION
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Detail:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Occlusion:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaTestRef: 0.5
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EmissionScaleUI: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Lightmapping: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 0.99999994}
+    - _EmissionColorUI: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColorWithMapUI: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
 --- !u!1 &1939857328
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,6 +2088,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7d4a729ae3f80437b826f95e71f9c942, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1972760754
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8546996133407889402, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_Name
+      value: PrefabModeExample_AssetReference
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
 --- !u!1 &2123536157
 GameObject:
   m_ObjectHideFlags: 0
@@ -1442,7 +2161,7 @@ GameObject:
   - component: {fileID: 2123536163}
   - component: {fileID: 2123536162}
   m_Layer: 0
-  m_Name: Cube
+  m_Name: Sample04_ArrangedValues
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1524,7 +2243,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2123536162
 MonoBehaviour:
@@ -1562,10 +2281,14 @@ MonoBehaviour:
     boolValue: 0
     intValue: 0
     floatValue: 0
-    stringValue: 
+    stringValue: "\u3042\u306E\u30A4\u30FC\u30CF\u30C8\u30FC\u30F4\u30A9\u306E\u306A\u3093\u3068\u304B\u304B\u3093\u3068\u304B\n2\u884C\u76EE\n3\u884C\u76EE\n4\u884C\u76EE\u304C\u30AE\u30EA\u30AE\u30EA\u3046\u3064\u308B"
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myRangeInt
     type: 1
     fieldDefinedLocation:
@@ -1586,12 +2309,16 @@ MonoBehaviour:
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
     overrideValue: 0
     boolValue: 0
-    intValue: 0
+    intValue: -1
     floatValue: 0
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myRangeFloat
     type: 2
     fieldDefinedLocation:
@@ -1610,14 +2337,18 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 0
+    overrideValue: 1
     boolValue: 0
     intValue: 0
-    floatValue: 1
+    floatValue: 3.89
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
   - fieldName: myEnum
     type: 1
     fieldDefinedLocation:
@@ -1636,14 +2367,18 @@ MonoBehaviour:
     vector2InitialValue: {x: 0, y: 0}
     vector3InitialValue: {x: 0, y: 0, z: 0}
     quaternionInitialValue: {x: 0, y: 0, z: 0, w: 1}
-    overrideValue: 0
+    overrideValue: 1
     boolValue: 0
-    intValue: 0
+    intValue: 1234
     floatValue: 0
     stringValue: 
     vector2Value: {x: 0, y: 0}
     vector3Value: {x: 0, y: 0, z: 0}
     quaternionValue: {x: 0, y: 0, z: 0, w: 1}
+    audioClipValue: {fileID: 0}
+    humanoidAnimationClipValue: {fileID: 0}
+    itemReferenceValue: {fileID: 0}
+    materialValue: {fileID: 0}
 --- !u!114 &2123536163
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1659,9 +2394,9 @@ MonoBehaviour:
   sourceCodeAsset: {fileID: 0}
   sourceCode: "// @field(string), @textArea\r\nconst myLongText = \"\";\r\n\r\n//
     @field(int), @range(-10, 20)\r\nconst myRangeInt = 0;;\r\n\r\n// @field(float),
-    @range(0.1, 5.0)\r\nconst myRangeFloat = 1;;\r\n\r\n// NOTE: enum\u306F\u307E\u3060\u5BFE\u5FDC\u3067\u304D\u3066\u3044\u306A\u3044\r\n//
+    @range(0.1, 5.0)\r\nconst myRangeFloat = 3.89;;\r\n\r\n// NOTE: enum\u306F\u307E\u3060\u5BFE\u5FDC\u3067\u304D\u3066\u3044\u306A\u3044\r\n//
     @field(int), @enum(\"OptionA\", \"2\u3064\u76EE\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\",
-    \"No.3\")\r\nconst myEnum = 0;;\r\n\r\n$.onInteract(() => { \r\n  $.log(`long
+    \"No.3\")\r\nconst myEnum = 1234;;\r\n\r\n$.onInteract(() => { \r\n  $.log(`long
     text... ${myLongText}`);\r\n\r\n  $.log(`range int... ${myRangeInt}`);\r\n  $.log(`range
     float... ${myRangeFloat}`);\r\n\r\n  $.log(`enum... ${myEnum}`);\r\n});\r\n"
 --- !u!114 &2123536164

--- a/Assets/Internal/Scenes/TestScene.unity
+++ b/Assets/Internal/Scenes/TestScene.unity
@@ -222,7 +222,7 @@ Transform:
   m_Children:
   - {fileID: 1087842112}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &62710053
 MonoBehaviour:
@@ -448,63 +448,6 @@ Transform:
   m_Father: {fileID: 1411427678}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &345732283
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1866279324507332140, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
-      propertyPath: m_Name
-      value: Sample02_Prefab_With_Gimmick
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
 --- !u!1 &395168188
 GameObject:
   m_ObjectHideFlags: 0
@@ -603,7 +546,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &395168193
 MonoBehaviour:
@@ -807,7 +750,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &942585009
 MonoBehaviour:
@@ -1193,7 +1136,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1087842111
 GameObject:
@@ -1441,7 +1384,7 @@ Transform:
   m_Children:
   - {fileID: 341351982}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1411427679
 MonoBehaviour:
@@ -1489,8 +1432,6 @@ GameObject:
   - component: {fileID: 1792626621}
   - component: {fileID: 1792626620}
   - component: {fileID: 1792626619}
-  - component: {fileID: 1792626630}
-  - component: {fileID: 1792626629}
   - component: {fileID: 1792626628}
   - component: {fileID: 1792626627}
   - component: {fileID: 1792626626}
@@ -1777,7 +1718,7 @@ Transform:
   m_Children:
   - {fileID: 712110325}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1792626626
 MonoBehaviour:
@@ -1826,38 +1767,6 @@ MonoBehaviour:
   worldItemReferences:
   - id: otherItemInstance
     item: {fileID: 395168195}
---- !u!114 &1792626629
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1792626618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff21d610f06941bd98a6fc9217c79607, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  humanoidAnimations:
-  - id: myMotion
-    animation: {fileID: 0}
-    humanoidAnimation: {fileID: 0}
---- !u!114 &1792626630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1792626618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d598b4b653f4fba944e3077caab98f5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  itemAudioSets:
-  - id: myAudio
-    audioClip: {fileID: 0}
-    loop: 0
 --- !u!1 &1815628113
 GameObject:
   m_ObjectHideFlags: 0
@@ -2101,7 +2010,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8546996133407889403, guid: 9c523678b54c1eb44825d51f5672ff9c, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2243,7 +2152,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2123536162
 MonoBehaviour:
@@ -2424,7 +2333,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1866279324507332131, guid: c6125a4d1fb913a4da37dbc8a300d26f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2485,7 +2394,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4539557075613711519, guid: da0a31fd476111949b875c9a8a0b0a66, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4539557075613711519, guid: da0a31fd476111949b875c9a8a0b0a66, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
fixed #4

- #4 のコメントに入れた5種類の機能に対応した。
- PropertyDrawerが散らかってきたのでリファクタも行った

このPRによって書けるようになる `// @field` の例

```
// @field(AudioClip)
const myAudio = $.audio("");
//変数名がidに再利用されるので生成コードはこうなる: const myAudio = $.audio("myAudio");

// @field(HumanoidAnimation)
const myMotion = $.humanoidAnimation("");

// @field(WorldItem)
const otherItemInstance = $.worldItemReference("");

// @field(WorldItemTemplate)
const creatableItem = new WorldItemTemplateId("");

// @field(Material)
const myRendererMaterial = $.material("");


$.onInteract(() => { 
  $.log("try play audio...");
  myAudio.play();
});
```

![image](https://github.com/user-attachments/assets/7c605f44-d9f3-430d-a3a0-3b417026afa2)

後からいじるかも

- 現在はアセットがnullのままでも `~List` を生成しているが、nullのアセットは無視したほうがいいかも
- 上記の例でidに `""` じゃなくて `"id"` をちゃんと書く前提にしたら変数名を使い回さないでいいし健全なのでは
    - この路線で行く場合、アセット系の型定義は細かく書かないで `// @field(object)` くらいでいいという話にできる…かも
    - 後からやると破壊的なので、次のリリースまでになんか結論を出したい
