### PR TITLE
Unity Package Managerが動いてそうなのを確認する

### DIFF
--- a/Assets/Baxter/ClusterScriptExtensions/package.json
+++ b/Assets/Baxter/ClusterScriptExtensions/package.json
@@ -3,8 +3,8 @@
     "displayName": "ClusterScriptExtensions",
     "version": "0.1.0",
     "unity": "2021.3",
-    "author": "malaybaku",
-    "description": "",
+    "author": "Baxter",
+    "description": "Extension project for ClusterScript",
     "dependencies": {},
     "samples": []
 }

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ CS Extensions と連動するスクリプトを作成するには [Cluster Scrip
 
 その後、 [Releases](https://github.com/malaybaku/ClusterScriptExtensions/releases) に含まれる `.unitypackage` ファイルをダウンロードし、プロジェクトに導入します。
 
+Unity Package Managerを使用する場合、 `Packages/manifest.json` で `dependencies` に下記を追記する方法でも導入できます。
+末尾のバージョン値は [Releases](https://github.com/malaybaku/ClusterScriptExtensions/releases) で記載された、参照したい CS Extensions のリリースバージョンを指定します。
 
-※UPMによる配布も計画していますが、コードの安定性やDLLの同梱方式を検討中のため未対応です。
+```
+"com.baxter.cs-extensions": "https://github.com/malaybaku/ClusterScriptExtensions.git?path=Assets/Baxter/ClusterScriptExtensions#v0.1.0",
+```
 
 
 ## How to Use


### PR DESCRIPTION
fixed #5 

- 基本的にはもう動いてたので文書的な微調整だけ行った
- 次のリリースからは(UniVRMらへんを参考に) `.unitypackage` と合わせてUPMのインストールについて併記する
